### PR TITLE
Add support for mbedtls to rust-native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 sgx = ["mbedtls"]
 
 [dependencies]
-mbedtls = { features = ["threading", "pkcs12", "pkcs12_rc2", "std"], git = "https://github.com/fortanix/rust-mbedtls", branch = "master", optional = true }
+mbedtls = { version = "0.5.1", features = ["threading", "pkcs12", "pkcs12_rc2", "std"], optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 security-framework = "0.3.1"
@@ -25,7 +25,7 @@ tempfile = "3.0"
 schannel = "0.1.16"
 
 [target.'cfg(feature = "mbedtls")'.dependencies]
-mbedtls = { features = ["threading", "threading", "pkcs12", "pkcs12_rc2", "std"], git = "https://github.com/fortanix/rust-mbedtls", branch = "master" }
+mbedtls = { version = "0.5.1", features = ["threading", "pkcs12", "pkcs12_rc2", "std"], optional = true }
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios", feature = "mbedtls")))'.dependencies]
 log = "0.4.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 sgx = ["mbedtls"]
 
 [dependencies]
-mbedtls = { features = ["pkcs12", "pkcs12_rc2", "std"], git = "https://github.com/fortanix/rust-mbedtls", branch = "master", optional = true }
+mbedtls = { features = ["threading", "pkcs12", "pkcs12_rc2", "std"], git = "https://github.com/fortanix/rust-mbedtls", branch = "master", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 security-framework = "0.3.1"
@@ -25,7 +25,7 @@ tempfile = "3.0"
 schannel = "0.1.16"
 
 [target.'cfg(feature = "mbedtls")'.dependencies]
-mbedtls = { features = ["threading", "pkcs12", "pkcs12_rc2", "std"], git = "https://github.com/fortanix/rust-mbedtls", branch = "master" }
+mbedtls = { features = ["threading", "threading", "pkcs12", "pkcs12_rc2", "std"], git = "https://github.com/fortanix/rust-mbedtls", branch = "master" }
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios", feature = "mbedtls")))'.dependencies]
 log = "0.4.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ readme = "README.md"
 sgx = ["mbedtls"]
 
 [dependencies]
-#mbedtls = { features = ["pkcs12", "pkcs12_rc2", "std"], git = "https://github.com/fortanix/rust-mbedtls", branch = "master", optional = true }
-mbedtls = { features = ["threading", "pkcs12", "pkcs12_rc2", "std"], path = "../rust-mbedtls/mbedtls", optional = true }
+mbedtls = { features = ["pkcs12", "pkcs12_rc2", "std"], git = "https://github.com/fortanix/rust-mbedtls", branch = "master", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 security-framework = "0.3.1"
@@ -26,8 +25,7 @@ tempfile = "3.0"
 schannel = "0.1.16"
 
 [target.'cfg(feature = "mbedtls")'.dependencies]
-#mbedtls = { features = ["threading", "pkcs12", "pkcs12_rc2", "std"], git = "https://github.com/fortanix/rust-mbedtls", branch = "master" }
-mbedtls = { features = ["threading", "pkcs12", "pkcs12_rc2", "std"], path = "../rust-mbedtls/mbedtls" }
+mbedtls = { features = ["threading", "pkcs12", "pkcs12_rc2", "std"], git = "https://github.com/fortanix/rust-mbedtls", branch = "master" }
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios", feature = "mbedtls")))'.dependencies]
 log = "0.4.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,12 @@ repository = "https://github.com/sfackler/rust-native-tls"
 readme = "README.md"
 
 [features]
-vendored = ["openssl/vendored"]
+#vendored = ["openssl/vendored"]
+sgx = ["mbedtls"]
+
+[dependencies]
+#mbedtls = { features = ["pkcs12", "pkcs12_rc2", "std"], git = "https://github.com/fortanix/rust-mbedtls", branch = "master", optional = true }
+mbedtls = { features = ["threading", "pkcs12", "pkcs12_rc2", "std"], path = "../rust-mbedtls/mbedtls", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 security-framework = "0.3.1"
@@ -20,7 +25,11 @@ tempfile = "3.0"
 [target.'cfg(target_os = "windows")'.dependencies]
 schannel = "0.1.16"
 
-[target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
+[target.'cfg(feature = "mbedtls")'.dependencies]
+#mbedtls = { features = ["threading", "pkcs12", "pkcs12_rc2", "std"], git = "https://github.com/fortanix/rust-mbedtls", branch = "master" }
+mbedtls = { features = ["threading", "pkcs12", "pkcs12_rc2", "std"], path = "../rust-mbedtls/mbedtls" }
+
+[target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios", feature = "mbedtls")))'.dependencies]
 log = "0.4.5"
 openssl = "0.10.25"
 openssl-sys = "0.9.30"

--- a/src/imp/mbedtls.rs
+++ b/src/imp/mbedtls.rs
@@ -440,7 +440,8 @@ impl<S> TlsStream<S> {
     }
 
     pub fn buffered_read_size(&self) -> Result<usize, Error> {
-        Ok(unsafe { (*self.session).bytes_available() })
+        //Ok(unsafe { (*self.session).bytes_available() })
+        Err(Error::Custom("Waiting on https://github.com/fortanix/rust-mbedtls/pull/52".to_owned()))
     }
 
     pub fn peer_certificate(&self) -> Result<Option<Certificate>, Error> {

--- a/src/imp/mbedtls.rs
+++ b/src/imp/mbedtls.rs
@@ -1,0 +1,510 @@
+extern crate mbedtls;
+
+use self::mbedtls::pk::Pk;
+use self::mbedtls::x509::certificate::{Certificate as MbedtlsCert, LinkedCertificate};
+use self::mbedtls::pkcs12::{Pfx, Pkcs12Error};
+use self::mbedtls::hash::{Md, Type as MdType};
+use self::mbedtls::ssl::config::{Endpoint, Preset, Transport};
+use self::mbedtls::ssl::{Config, Context, Session, Version};
+use self::mbedtls::x509::certificate::List as CertList;
+use self::mbedtls::rng::{OsEntropy, CtrDrbg};
+use self::mbedtls::Error as TlsError;
+use self::mbedtls::Result as TlsResult;
+
+use std::error;
+use std::fmt;
+use std::io::{self, Read};
+use std::fs;
+
+use {Protocol, TlsAcceptorBuilder, TlsConnectorBuilder};
+
+fn load_ca_certs(dir: &str) -> TlsResult<Vec<::Certificate>> {
+    let paths = fs::read_dir(dir).map_err(|_| TlsError::X509FileIoError)?;
+
+    let mut certs = Vec::new();
+
+    for path in paths {
+
+        if let Ok(mut file) = fs::File::open(path.unwrap().path()) {
+            let mut contents = Vec::new();
+            if let Ok(_) = file.read_to_end(&mut contents) {
+                contents.push(0); // needs NULL terminator
+                if let Ok(cert) = ::Certificate::from_pem(&contents) {
+                    certs.push(cert);
+                }
+            }
+        }
+    }
+
+    Ok(certs)
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Normal(TlsError),
+    Pkcs12(Pkcs12Error),
+    Custom(String),
+}
+
+impl From<TlsError> for Error {
+    fn from(err: TlsError) -> Error {
+        Error::Normal(err)
+    }
+}
+
+impl From<Pkcs12Error> for Error {
+    fn from(err: Pkcs12Error) -> Error {
+        Error::Pkcs12(err)
+    }
+}
+
+impl<S> From<TlsError> for HandshakeError<S> {
+    fn from(e: TlsError) -> HandshakeError<S> {
+        HandshakeError::Failure(e.into())
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::Normal(ref e) => error::Error::description(e),
+            Error::Pkcs12(ref e) => error::Error::description(e),
+            Error::Custom(ref e) => &e,
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::Normal(ref e) => error::Error::cause(e),
+            Error::Pkcs12(ref e) => error::Error::cause(e),
+            Error::Custom(ref _e) => None,
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Normal(ref e) => fmt::Display::fmt(e, fmt),
+            Error::Pkcs12(ref e) => fmt::Display::fmt(e, fmt),
+            Error::Custom(ref e) => fmt::Display::fmt(e, fmt),
+        }
+    }
+}
+
+fn map_version(protocol: Option<Protocol>) -> Option<Version> {
+    if let Some(protocol) = protocol {
+        match protocol {
+            Protocol::Sslv3 => Some(Version::Ssl3),
+            Protocol::Tlsv10 => Some(Version::Tls1_0),
+            Protocol::Tlsv11 => Some(Version::Tls1_1),
+            Protocol::Tlsv12 => Some(Version::Tls1_2),
+            _ => None
+        }
+    } else {
+        None
+    }
+
+}
+
+pub struct Identity(Pfx);
+unsafe impl Sync for Identity {}
+unsafe impl Send for Identity {}
+
+impl Identity {
+    pub fn from_pkcs12(buf: &[u8], pass: &str) -> Result<Identity, Error> {
+        let pkcs12 = Pfx::parse(buf).map_err(Error::Pkcs12)?;
+        let decrypted = pkcs12.decrypt(&pass, None).map_err(Error::Pkcs12)?;
+        Ok(Identity(decrypted))
+    }
+}
+
+
+#[derive(Clone)]
+pub struct Certificate(MbedtlsCert);
+unsafe impl Sync for Certificate {}
+
+impl Certificate {
+    pub fn from_der(buf: &[u8]) -> Result<Certificate, Error> {
+        let cert = MbedtlsCert::from_der(buf).map_err(Error::Normal)?;
+        Ok(Certificate(cert))
+    }
+
+    pub fn from_pem(buf: &[u8]) -> Result<Certificate, Error> {
+        // Mbedtls needs there to be a trailing NULL byte ...
+        let mut pem = buf.to_vec();
+        pem.push(0);
+        let cert = MbedtlsCert::from_pem(&pem).map_err(Error::Normal)?;
+        Ok(Certificate(cert))
+    }
+
+    pub fn to_der(&self) -> Result<Vec<u8>, Error> {
+        let der = self.0.as_der().to_vec();
+        Ok(der)
+    }
+}
+
+fn cert_to_vec(certs_in: &[::Certificate]) -> Vec<MbedtlsCert> {
+    let mut certs : Vec<MbedtlsCert> = Vec::with_capacity(certs_in.len());
+    for cert in certs_in {
+        certs.push((cert.0).0.clone())
+    }
+    certs
+}
+
+struct TlsState {
+    ca_certs: *mut Vec<MbedtlsCert>,
+    ca_cert_list: *mut CertList<'static>,
+    cred_pk: *mut Pk,
+    cred_certs: *mut Vec<MbedtlsCert>,
+    cred_cert_list: *mut CertList<'static>,
+    entropy: *mut OsEntropy<'static>,
+    rng: *mut CtrDrbg<'static>,
+    config: *mut Config<'static>,
+    ctx: *mut Context<'static>,
+}
+
+unsafe impl Sync for TlsState {}
+unsafe impl Send for TlsState {}
+
+impl Clone for TlsState {
+    fn clone(&self) -> TlsState {
+        panic!("yolo")
+    }
+}
+
+impl Drop for TlsState {
+    fn drop(&mut self) {
+        unsafe {
+            Box::from_raw(self.ctx);
+            Box::from_raw(self.config);
+            Box::from_raw(self.rng);
+            Box::from_raw(self.entropy);
+
+            if self.cred_cert_list != ::std::ptr::null_mut() {
+                Box::from_raw(self.cred_cert_list);
+            }
+            if self.cred_certs != ::std::ptr::null_mut() {
+                Box::from_raw(self.cred_certs);
+            }
+            if self.cred_pk != ::std::ptr::null_mut() {
+                Box::from_raw(self.cred_pk);
+            }
+
+            if self.ca_cert_list != ::std::ptr::null_mut() {
+                Box::from_raw(self.ca_cert_list);
+            }
+
+            if self.ca_certs != ::std::ptr::null_mut() {
+                Box::from_raw(self.ca_certs);
+            }
+        }
+    }
+}
+
+impl TlsState {
+    fn new_client(trust_roots: &[::Certificate],
+                  min_version: Option<Version>,
+                  max_version: Option<Version>,
+                  accept_invalid_certs: bool) -> TlsResult<Self> {
+
+        unsafe {
+            let ca_vec = Box::into_raw(Box::new(cert_to_vec(trust_roots)));
+            let ca_list = Box::into_raw(Box::new(CertList::from_vec(&mut *ca_vec).ok_or(TlsError::AesInvalidKeyLength)?));
+            let entropy = Box::into_raw(Box::new(OsEntropy::new()));
+            let rng = Box::into_raw(Box::new(CtrDrbg::new(&mut *entropy, None)?));
+            let config = Box::into_raw(Box::new(Config::new(Endpoint::Client, Transport::Stream, Preset::Default)));
+            (*config).set_rng(Some(&mut *rng));
+            (*config).set_ca_list(Some(&mut *ca_list), None);
+
+            if accept_invalid_certs {
+                (*config).set_authmode(mbedtls::ssl::config::AuthMode::None);
+            }
+
+            if let Some(min_version) = min_version {
+                (*config).set_min_version(min_version)?;
+            }
+            if let Some(max_version) = max_version {
+                (*config).set_max_version(max_version)?;
+            }
+
+            let ctx = Box::into_raw(Box::new(Context::new(&*config)?));
+
+            Ok(TlsState {
+                ca_certs: ca_vec,
+                ca_cert_list: ca_list,
+                cred_pk: ::std::ptr::null_mut(),
+                cred_certs: ::std::ptr::null_mut(),
+                cred_cert_list: ::std::ptr::null_mut(),
+                entropy: entropy,
+                rng: rng,
+                config: config,
+                ctx: ctx,
+            })
+        }
+    }
+
+    fn new_server(cert_chain: &[MbedtlsCert],
+                  key: &mut Pk,
+                  min_version: Option<Version>,
+                  max_version: Option<Version>) -> TlsResult<Self> {
+        fn pk_clone(pk: &mut Pk) -> TlsResult<Pk> {
+            let der = pk.write_private_der_vec()?;
+            Pk::from_private_key(&der, None)
+        }
+
+        unsafe {
+            let pk = Box::into_raw(Box::new(pk_clone(key)?));
+            let cert_chain = Box::into_raw(Box::new(cert_chain.to_vec()));
+            let cert_list = Box::into_raw(Box::new(CertList::from_vec(&mut *cert_chain).ok_or(TlsError::CamelliaInvalidInputLength)?));
+            let entropy = Box::into_raw(Box::new(OsEntropy::new()));
+            let rng = Box::into_raw(Box::new(CtrDrbg::new(&mut *entropy, None)?));
+            let config = Box::into_raw(Box::new(Config::new(Endpoint::Server, Transport::Stream, Preset::Default)));
+            (*config).set_rng(Some(&mut *rng));
+            (*config).push_cert(&mut *cert_list, &mut *pk)?;
+
+            if let Some(min_version) = min_version {
+                (*config).set_min_version(min_version)?;
+            }
+            if let Some(max_version) = max_version {
+                (*config).set_max_version(max_version)?;
+            }
+
+            let ctx = Box::into_raw(Box::new(Context::new(&*config)?));
+
+            Ok(TlsState {
+                ca_certs: ::std::ptr::null_mut(),
+                ca_cert_list: ::std::ptr::null_mut(),
+                cred_pk: pk,
+                cred_certs: cert_chain,
+                cred_cert_list: cert_list,
+                entropy: entropy,
+                rng: rng,
+                config: config,
+                ctx: ctx,
+            })
+        }
+    }
+
+    fn establish<S: io::Read + io::Write>(&self, stream: S, hostname: Option<&str>) -> TlsResult<TlsStream<S>> {
+        unsafe {
+            let stream_ptr = Box::into_raw(Box::new(stream));
+            let session = (*self.ctx).establish(&mut *stream_ptr, hostname)?;
+            let yolo_session = Box::into_raw(Box::new(std::mem::transmute::<Session<'_>, Session<'static>>(session)));
+            Ok(TlsStream {
+                session: yolo_session,
+                socket: stream_ptr,
+            })
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TlsStream<S> {
+    session: *mut Session<'static>,
+    socket: *mut S,
+}
+
+unsafe impl<S> Sync for TlsStream<S> {}
+unsafe impl<S> Send for TlsStream<S> {}
+
+impl<S> Drop for TlsStream<S> {
+    fn drop(&mut self) {
+        //println!("Dropping TlsStream");
+        unsafe {
+            Box::from_raw(self.session);
+            Box::from_raw(self.socket);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct MidHandshakeTlsStream<S> {
+    stream: TlsStream<S>,
+    error: Error,
+}
+
+pub enum HandshakeError<S> {
+    Failure(Error),
+    WouldBlock(MidHandshakeTlsStream<S>),
+}
+
+impl<S> MidHandshakeTlsStream<S> {
+    pub fn get_ref(&self) -> &S {
+        self.stream.get_ref()
+    }
+
+    pub fn get_mut(&mut self) -> &mut S {
+        self.stream.get_mut()
+    }
+}
+
+impl<S> MidHandshakeTlsStream<S>
+where
+    S: io::Read + io::Write,
+{
+    pub fn handshake(self) -> Result<TlsStream<S>, HandshakeError<S>> {
+        panic!("what to do?");
+        Ok(self.stream) // ???
+    }
+}
+
+#[derive(Clone)]
+pub struct TlsConnector {
+    state: TlsState,
+    accept_bad_hostname: bool,
+}
+
+impl TlsConnector {
+    pub fn new(builder: &TlsConnectorBuilder) -> Result<TlsConnector, Error> {
+        if builder.identity.is_some() {
+            return Err(Error::Custom("Client authentication not supported".to_owned()));
+        }
+
+        let min_version = map_version(builder.min_protocol);
+        let max_version = map_version(builder.max_protocol);
+
+        let state = if builder.root_certificates.len() > 0 {
+            TlsState::new_client(&builder.root_certificates, min_version, max_version, builder.accept_invalid_certs)?
+        } else {
+            let trust_roots = load_ca_certs("/usr/share/ca-certificates/mozilla")?;
+            TlsState::new_client(&trust_roots, min_version, max_version, builder.accept_invalid_certs)?
+        };
+
+        Ok(TlsConnector { state, accept_bad_hostname: builder.accept_invalid_certs })
+    }
+
+    pub fn connect<S>(&self, domain: &str, stream: S) -> Result<TlsStream<S>, HandshakeError<S>>
+    where
+        S: io::Read + io::Write
+    {
+        let channel = if self.accept_bad_hostname {
+            self.state.establish(stream, None)?
+        } else {
+            self.state.establish(stream, Some(domain))?
+        };
+
+        //println!("After establish, stream is {:?} at {:?}", channel.socket, channel.socket as *const S);
+
+        Ok(channel)
+    }
+}
+
+#[derive(Clone)]
+pub struct TlsAcceptor {
+    state: TlsState,
+}
+
+impl TlsAcceptor {
+    pub fn new(builder: &TlsAcceptorBuilder) -> Result<TlsAcceptor, Error> {
+
+        let mut keys = (builder.identity.0).0.private_keys()?;
+        let certificates = (builder.identity.0).0.certificates()?;
+
+        if keys.len() != 1 {
+            return Err(Error::Custom("Unexpected number of keys in PKCS12 file".to_owned()))
+        }
+        if certificates.len() == 0 {
+            return Err(Error::Custom("PKCS12 file is missing certificate chain".to_owned()))
+        }
+
+        let mut cert_chain = vec![];
+
+        for cert in certificates {
+            cert_chain.push(cert.0);
+        }
+
+        let state = TlsState::new_server(&cert_chain, &mut keys[0].0,
+                                         map_version(builder.min_protocol),
+                                         map_version(builder.max_protocol)).map_err(Error::Normal)?;
+
+        Ok(TlsAcceptor { state })
+    }
+
+    pub fn accept<S>(&self, stream: S) -> Result<TlsStream<S>, HandshakeError<S>>
+    where
+        S: io::Read + io::Write
+    {
+        Ok(self.state.establish(stream, None)?)
+    }
+}
+
+impl<S> TlsStream<S> {
+
+    pub fn get_ref(&self) -> &S {
+        panic!("no");
+    }
+
+    pub fn get_mut(&mut self) -> &mut S {
+        panic!("no");
+    }
+
+    pub fn buffered_read_size(&self) -> Result<usize, Error> {
+        Ok(unsafe { (*self.session).bytes_available() })
+    }
+
+    pub fn peer_certificate(&self) -> Result<Option<Certificate>, Error> {
+        match unsafe { (*self.session).peer_cert() } {
+            None => Ok(None),
+            Some(mut certs) => {
+                let cert = certs.next();
+                match cert {
+                    None => Ok(None),
+                    Some(c) => Ok(Some(Certificate::from_der(c.as_der())?))
+                }
+            }
+        }
+    }
+
+    pub fn tls_server_end_point(&self) -> Result<Option<Vec<u8>>, Error> {
+        let cert = match self.peer_certificate()? {
+            Some(cert) => cert,
+            None => return Ok(None),
+        };
+
+        let lcert : &LinkedCertificate = &*(cert.0);
+
+        let md = match lcert.digest_type() {
+            MdType::Md5 | MdType::Sha1 => MdType::Sha256,
+            md => md,
+        };
+
+        let der = cert.to_der()?;
+        let mut digest = vec![0; 64];
+        let len = Md::hash(md, &der, &mut digest).map_err(Error::Normal)?;
+        digest.truncate(len);
+
+        Ok(Some(digest))
+    }
+
+    pub fn shutdown(&mut self) -> io::Result<()> {
+        // Shutdown happens as a result of drop ...
+        Ok(())
+    }
+}
+
+impl<S: io::Read + io::Write> io::Read for TlsStream<S> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        unsafe {
+            (*self.session).read(buf)
+        }
+    }
+}
+
+impl<S: io::Read + io::Write> io::Write for TlsStream<S> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        unsafe {
+            //println!("writing to {:?}", self);
+            let r = (*self.session).write(buf);
+            //println!("back from writing to {:?} {:?}", self, r);
+            r
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        unsafe {
+            (*self.session).flush()
+        }
+    }
+}
+

--- a/src/imp/mbedtls.rs
+++ b/src/imp/mbedtls.rs
@@ -108,14 +108,18 @@ fn map_version(protocol: Option<Protocol>) -> Option<Version> {
 }
 
 pub struct Identity(Pfx);
-unsafe impl Sync for Identity {}
-unsafe impl Send for Identity {}
 
 impl Identity {
     pub fn from_pkcs12(buf: &[u8], pass: &str) -> Result<Identity, Error> {
         let pkcs12 = Pfx::parse(buf).map_err(Error::Pkcs12)?;
         let decrypted = pkcs12.decrypt(&pass, None).map_err(Error::Pkcs12)?;
         Ok(Identity(decrypted))
+    }
+}
+
+impl Clone for Identity {
+    fn clone(&self) -> Self {
+        Identity(self.0.clone())
     }
 }
 

--- a/src/imp/mbedtls.rs
+++ b/src/imp/mbedtls.rs
@@ -165,7 +165,6 @@ pub struct TlsStream<S> {
     socket: *mut S,
 }
 
-/// ???
 unsafe impl<S> Sync for TlsStream<S> {}
 unsafe impl<S> Send for TlsStream<S> {}
 
@@ -229,8 +228,7 @@ where
     S: io::Read + io::Write,
 {
     pub fn handshake(self) -> Result<TlsStream<S>, HandshakeError<S>> {
-        panic!("what to do?");
-        Ok(self.stream) // ???
+        Ok(self.stream)
     }
 }
 
@@ -400,11 +398,11 @@ impl TlsAcceptor {
 impl<S> TlsStream<S> {
 
     pub fn get_ref(&self) -> &S {
-        panic!("no");
+        unsafe { self.socket.as_ref().unwrap() }
     }
 
     pub fn get_mut(&mut self) -> &mut S {
-        panic!("no");
+        unsafe { self.socket.as_mut().unwrap() }
     }
 
     pub fn buffered_read_size(&self) -> Result<usize, Error> {

--- a/src/imp/mbedtls.rs
+++ b/src/imp/mbedtls.rs
@@ -24,7 +24,6 @@ fn load_ca_certs(dir: &str) -> TlsResult<Vec<::Certificate>> {
     let mut certs = Vec::new();
 
     for path in paths {
-
         if let Ok(mut file) = fs::File::open(path.unwrap().path()) {
             let mut contents = Vec::new();
             if let Ok(_) = file.read_to_end(&mut contents) {
@@ -104,7 +103,6 @@ fn map_version(protocol: Option<Protocol>) -> Option<Version> {
     } else {
         None
     }
-
 }
 
 pub struct Identity(Pfx);
@@ -149,11 +147,7 @@ impl Certificate {
 }
 
 fn cert_to_vec(certs_in: &[::Certificate]) -> Vec<MbedtlsCert> {
-    let mut certs : Vec<MbedtlsCert> = Vec::with_capacity(certs_in.len());
-    for cert in certs_in {
-        certs.push((cert.0).0.clone())
-    }
-    certs
+    certs_in.iter().map(|cert| (cert.0).0.clone()).collect()
 }
 
 #[derive(Debug)]
@@ -414,8 +408,7 @@ impl<S> TlsStream<S> {
     }
 
     pub fn buffered_read_size(&self) -> Result<usize, Error> {
-        //Ok(unsafe { (*self.session).bytes_available() })
-        Err(Error::Custom("Waiting on https://github.com/fortanix/rust-mbedtls/pull/52".to_owned()))
+        Ok(unsafe { (*self.session).bytes_available() })
     }
 
     pub fn peer_certificate(&self) -> Result<Option<Certificate>, Error> {

--- a/src/imp/mbedtls.rs
+++ b/src/imp/mbedtls.rs
@@ -485,10 +485,7 @@ impl<S: io::Read + io::Write> io::Read for TlsStream<S> {
 impl<S: io::Read + io::Write> io::Write for TlsStream<S> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         unsafe {
-            //println!("writing to {:?}", self);
-            let r = (*self.session).write(buf);
-            //println!("back from writing to {:?} {:?}", self, r);
-            r
+            (*self.session).write(buf)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,11 @@ mod imp;
 #[cfg(target_os = "windows")]
 #[path = "imp/schannel.rs"]
 mod imp;
-#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
+#[cfg(feature = "mbedtls")]
+#[path = "imp/mbedtls.rs"]
+mod imp;
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios", feature = "mbedtls")))]
 #[path = "imp/openssl.rs"]
 mod imp;
 


### PR DESCRIPTION
This PR is not for merging to this branch but just for review/commentary before I try opening a PR with upstream. There is a lot of unsafe, a lot of raw pointer manipulation in here. I do not believe upstream will take this PR as is.

I certainly think the rust-mbedtls API could be improved, such that it would be possible to implement this without all the unsafe. This would of course benefit any other current or potential users. See https://github.com/fortanix/rust-mbedtls/issues/4. However I have **no idea** how to go about fixing our crates API. Suggestions very welcome.