### PR TITLE
Add temporary support for retrieving TLS certificate chain

### DIFF
--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -1,7 +1,7 @@
 extern crate schannel;
 
 use self::schannel::cert_context::{CertContext, HashAlgorithm, KeySpec};
-use self::schannel::cert_store::{CertAdd, CertStore, Memory, PfxImportOptions};
+use self::schannel::cert_store::{CertAdd, Certs, CertStore, Memory, PfxImportOptions};
 use self::schannel::crypt_prov::{AcquireOptions, ProviderType};
 use self::schannel::schannel_cred::{Direction, Protocol, SchannelCred};
 use self::schannel::tls_stream;
@@ -204,7 +204,10 @@ where
 {
     pub fn handshake(self) -> Result<TlsStream<S>, HandshakeError<S>> {
         match self.0.handshake() {
-            Ok(s) => Ok(TlsStream(s)),
+            Ok(stream) => Ok(TlsStream {
+                stream,
+                store: None,
+            }),
             Err(e) => Err(e.into()),
         }
     }
@@ -318,7 +321,10 @@ impl TlsConnector {
             }
         }
         match builder.connect(cred, stream) {
-            Ok(s) => Ok(TlsStream(s)),
+            Ok(stream) => Ok(TlsStream {
+                stream,
+                store: None,
+            }),
             Err(e) => Err(e.into()),
         }
     }
@@ -350,53 +356,93 @@ impl TlsAcceptor {
         // FIXME we're probably missing the certificate chain?
         let cred = builder.acquire(Direction::Inbound)?;
         match tls_stream::Builder::new().accept(cred, stream) {
-            Ok(s) => Ok(TlsStream(s)),
+            Ok(stream) => Ok(TlsStream {
+                stream,
+                store: None,
+            }),
             Err(e) => Err(e.into()),
         }
     }
 }
 
-pub struct TlsStream<S>(tls_stream::TlsStream<S>);
+pub struct ChainIterator<'a, S: 'a> {
+    certs: Option<Certs<'a>>,
+    _stream: &'a TlsStream<S>,
+}
+
+impl<'a, S> Iterator for ChainIterator<'a, S> {
+    type Item = Certificate;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(certs) = self.certs.as_mut() {
+            return certs.next().map(Certificate);
+        }
+        None
+    }
+}
+
+pub struct TlsStream<S> {
+    stream: tls_stream::TlsStream<S>,
+    store: Option<CertStore>,
+}
 
 impl<S: fmt::Debug> fmt::Debug for TlsStream<S> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&self.0, fmt)
+        fmt::Debug::fmt(&self.stream, fmt)
     }
 }
 
 impl<S> TlsStream<S> {
     pub fn get_ref(&self) -> &S {
-        self.0.get_ref()
+        self.stream.get_ref()
     }
 
     pub fn get_mut(&mut self) -> &mut S {
-        self.0.get_mut()
+        self.stream.get_mut()
     }
 }
 
 impl<S: io::Read + io::Write> TlsStream<S> {
     pub fn buffered_read_size(&self) -> Result<usize, Error> {
-        Ok(self.0.get_buf().len())
+        Ok(self.stream.get_buf().len())
     }
 
     pub fn peer_certificate(&self) -> Result<Option<Certificate>, Error> {
-        match self.0.peer_certificate() {
+        match self.stream.peer_certificate() {
             Ok(cert) => Ok(Some(Certificate(cert))),
             Err(ref e) if e.raw_os_error() == Some(SEC_E_NO_CREDENTIALS as i32) => Ok(None),
             Err(e) => Err(Error(e)),
         }
     }
 
+    pub fn certificate_chain(&mut self) -> Result<ChainIterator<S>, Error> {
+        if self.store.is_none() {
+            match self.stream.peer_certificate() {
+                Ok(cert) => {
+                    self.store = cert.cert_store();
+                }
+                Err(ref e) if e.raw_os_error() == Some(SEC_E_NO_CREDENTIALS as i32) => {
+                    self.store = None;
+                }
+                Err(e) => return Err(Error(e)),
+            }
+        }
+        Ok(ChainIterator {
+            certs: self.store.as_ref().map(|c| c.certs()),
+            _stream: self,
+        })
+    }
+
     #[cfg(feature = "alpn")]
     pub fn negotiated_alpn(&self) -> Result<Option<Vec<u8>>, Error> {
-        Ok(self.0.negotiated_application_protocol()?)
+        Ok(self.stream.negotiated_application_protocol()?)
     }
 
     pub fn tls_server_end_point(&self) -> Result<Option<Vec<u8>>, Error> {
-        let cert = if self.0.is_server() {
-            self.0.certificate()
+        let cert = if self.stream.is_server() {
+            self.stream.certificate()
         } else {
-            self.0.peer_certificate()
+            self.stream.peer_certificate()
         };
 
         let cert = match cert {
@@ -418,24 +464,24 @@ impl<S: io::Read + io::Write> TlsStream<S> {
     }
 
     pub fn shutdown(&mut self) -> io::Result<()> {
-        self.0.shutdown()?;
+        self.stream.shutdown()?;
         Ok(())
     }
 }
 
 impl<S: io::Read + io::Write> io::Read for TlsStream<S> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.0.read(buf)
+        self.stream.read(buf)
     }
 }
 
 impl<S: io::Read + io::Write> io::Write for TlsStream<S> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.write(buf)
+        self.stream.write(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.0.flush()
+        self.stream.flush()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,17 @@ impl Certificate {
     }
 }
 
+/// An iterator over a certificate chain.
+pub struct ChainIterator<'a, S: 'a>(imp::ChainIterator<'a, S>);
+
+impl<'a, S> Iterator for ChainIterator<'a, S> {
+    type Item = Certificate;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(Certificate)
+    }
+}
+
 /// A TLS stream which has been interrupted midway through the handshake process.
 pub struct MidHandshakeTlsStream<S>(imp::MidHandshakeTlsStream<S>);
 
@@ -658,6 +669,11 @@ impl<S: io::Read + io::Write> TlsStream<S> {
     /// Returns the peer's leaf certificate, if available.
     pub fn peer_certificate(&self) -> Result<Option<Certificate>> {
         Ok(self.0.peer_certificate()?.map(Certificate))
+    }
+
+    /// Returns an iterator over certificate chain. It may be an empty iterator if chain not available.
+    pub fn certificate_chain(&mut self) -> Result<ChainIterator<S>> {
+        Ok(ChainIterator(self.0.certificate_chain()?))
     }
 
     /// Returns the tls-server-end-point channel binding data as defined in [RFC 5929].


### PR DESCRIPTION
Currently, `rust-native-tls` provides access only to the peer (leaf) certificate via `TlsStream::peer_certificate()`. This PR adds temporary support for retrieving the full TLS certificate chain from `TlsStream [ TlsStream::certificate_chain()]`,  which is required for use cases such as server certificate revocation checks.

While exploring this requirement, noticed an upstream pull request (117) for adding certificate chain support, but it has not been merged yet. Raised a feature request for retrieving the full certificate chain 343.

Meanwhile to unblock current development needs, this PR adapts only the certificate-chain related logic from that work, updates it to the current codebase, and validates the changes through local testing.
This PR is intended as a temporary solution and can be dropped once an upstream PR is merged or alternative solution becomes available. so the changes are maintained in a separate branch (`support-cert-chain`). 